### PR TITLE
scala3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: sbt ++${{ matrix.scala }} clean coverage test
 
       - name: test coverage
-        if: success()
+        if: success() && if: matrix.scala != '3.3.0'
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: Scala ${{ matrix.scala }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
     tags: ["v*"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
   workflow_dispatch:
 
 permissions:
@@ -13,14 +13,13 @@ permissions:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         scala:
-#          - 3.2.0
+          - 3.3.0
           - 2.13.11
           - 2.12.18
 
@@ -32,9 +31,9 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'sbt'
+          java-version: "17"
+          distribution: "temurin"
+          cache: "sbt"
 
       - name: build ${{ matrix.scala }}
         run: sbt ++${{ matrix.scala }} clean coverage test
@@ -56,7 +55,7 @@ jobs:
 
   publish:
     name: Publish Artifacts
-    needs: [ test ]
+    needs: [test]
     if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
     steps:
@@ -69,7 +68,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-          cache: 'sbt'
+          cache: "sbt"
 
       - name: Publish artifacts
         env:

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,2 @@
+version = "3.7.4"
+runner.dialect = scala3

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,10 @@
 import sbt.librarymanagement.For3Use2_13
 import Dependencies._
 
-def crossSettings[T](scalaVersion: String, if3: Seq[T], if2: Seq[T]) = {
-  CrossVersion.partialVersion(scalaVersion) match {
-    case Some((3, _)) => if3
-    case Some((2, 12 | 13)) => if2
-    case _ => Nil
+def crossSettings[T](scalaVersion: String, if3: T, if2: T) = {
+  scalaVersion match {
+    case version if version.startsWith("3") => if3
+    case _ => if2
   }
 }
 
@@ -24,6 +23,12 @@ organizationHomepage := Some(url("http://evolutiongaming.com"))
 scalaVersion := crossScalaVersions.value.head
 
 crossScalaVersions := Seq("2.13.11", "3.3.0", "2.12.18")
+
+scalacOptsFailOnWarn := crossSettings(
+  scalaVersion.value,
+  if3 = Some(false),
+  if2 = Some(true),
+)
 
 libraryDependencies ++= crossSettings(
   scalaVersion.value,

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import Dependencies._
 def crossSettings[T](scalaVersion: String, if3: T, if2: T) = {
   scalaVersion match {
     case version if version.startsWith("3") => if3
-    case _ => if2
+    case _                                  => if2
   }
 }
 
@@ -19,6 +19,12 @@ startYear := Some(2019)
 organizationName := "Evolution Gaming"
 
 organizationHomepage := Some(url("http://evolutiongaming.com"))
+coverageExcludedFiles := ".*CacheOpsCompat.*"
+coverageEnabled := crossSettings(
+  scalaVersion.value,
+  if3 = false,
+  if2 = true
+)
 
 scalaVersion := crossScalaVersions.value.head
 
@@ -27,7 +33,7 @@ crossScalaVersions := Seq("2.13.11", "3.3.0", "2.12.18")
 scalacOptsFailOnWarn := crossSettings(
   scalaVersion.value,
   if3 = Some(false),
-  if2 = Some(true),
+  if2 = Some(true)
 )
 
 libraryDependencies ++= crossSettings(
@@ -36,13 +42,17 @@ libraryDependencies ++= crossSettings(
   if2 = Seq(
     compilerPlugin(betterMonadicFor),
     compilerPlugin(`kind-projector` cross CrossVersion.full)
-  ),
+  )
 )
 
 scalacOptions ++= crossSettings(
   scalaVersion.value,
-  if3 = Seq("-Ykind-projector:underscores", "-language:implicitConversions", "-source:future"),
-  if2 = Seq("-Xsource:3", "-P:kind-projector:underscore-placeholders"),
+  if3 = Seq(
+    "-Ykind-projector:underscores",
+    "-language:implicitConversions",
+    "-source:future"
+  ),
+  if2 = Seq("-Xsource:3", "-P:kind-projector:underscore-placeholders")
 )
 
 libraryDependencies ++= Seq(
@@ -57,28 +67,28 @@ autoAPIMappings := true
 
 licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT")))
 
-description             := "Cache in Scala with cats-effect"
+description := "Cache in Scala with cats-effect"
 
 sonatypeCredentialHost := "s01.oss.sonatype.org"
 
 sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 
-Test / publishArtifact  := false
+Test / publishArtifact := false
 
-scmInfo                 := Some(
+scmInfo := Some(
   ScmInfo(
     url("https://github.com/evolution-gaming/scache"),
-    "git@github.com:evolution-gaming/scache.git",
-  ),
+    "git@github.com:evolution-gaming/scache.git"
+  )
 )
 
-developers              := List(
-    Developer(
-      "t3hnar",
-      "Yaroslav Klymko",
-      "yklymko@evolution.com",
-      url("https://github.com/t3hnar"),
-    )
+developers := List(
+  Developer(
+    "t3hnar",
+    "Yaroslav Klymko",
+    "yklymko@evolution.com",
+    url("https://github.com/t3hnar")
   )
+)
 
 enablePlugins(GitVersioning)

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ libraryDependencies ++= crossSettings(
 
 scalacOptions ++= crossSettings(
   scalaVersion.value,
-  if3 = Seq("-Ykind-projector:underscores", "-language:implicitConversions", "-source:future"),
+  if3 = Seq("-Ykind-projector:underscores", "-language:implicitConversions", "-explain"),
   if2 = Seq("-Xsource:3", "-P:kind-projector:underscore-placeholders"),
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ organizationHomepage := Some(url("http://evolutiongaming.com"))
 
 scalaVersion := crossScalaVersions.value.head
 
-crossScalaVersions := Seq("2.13.11", /*"3.2.0", */"2.12.18")
+crossScalaVersions := Seq("2.13.11", "3.3.0", "2.12.18")
 
 libraryDependencies ++= crossSettings(
   scalaVersion.value,
@@ -36,7 +36,7 @@ libraryDependencies ++= crossSettings(
 
 scalacOptions ++= crossSettings(
   scalaVersion.value,
-  if3 = Seq("-Ykind-projector:underscores", "-language:implicitConversions"),
+  if3 = Seq("-Ykind-projector:underscores", "-language:implicitConversions", "-source:future"),
   if2 = Seq("-Xsource:3", "-P:kind-projector:underscore-placeholders"),
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ libraryDependencies ++= crossSettings(
 
 scalacOptions ++= crossSettings(
   scalaVersion.value,
-  if3 = Seq("-Ykind-projector:underscores", "-language:implicitConversions", "-explain"),
+  if3 = Seq("-Ykind-projector:underscores", "-language:implicitConversions", "-source:future"),
   if2 = Seq("-Xsource:3", "-P:kind-projector:underscore-placeholders"),
 )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 object Dependencies {
 
   val scalatest        = "org.scalatest"       %% "scalatest"          % "3.2.16"
-  val `cats-helper`    = "com.evolutiongaming" %% "cats-helper"        % "3.5.0"
+  val `cats-helper`    = "com.evolutiongaming" %% "cats-helper"        % "3.6.0"
   val smetrics         = "com.evolutiongaming" %% "smetrics"           % "2.0.0"
   val `kind-projector` = "org.typelevel"        % "kind-projector"     % "0.13.2"
   val betterMonadicFor = "com.olegpy"          %% "better-monadic-for" % "0.3.1"

--- a/src/main/scala-2/com/evolution/scache/CacheOpsCompat.scala
+++ b/src/main/scala-2/com/evolution/scache/CacheOpsCompat.scala
@@ -1,0 +1,100 @@
+package com.evolution.scache
+
+import cats.MonadThrow
+import cats.effect.MonadCancel
+import cats.effect.Resource
+import cats.syntax.all._
+
+import scala.util.control.NoStackTrace
+
+object CacheOpsCompat {
+  private[scache] case object NoneError
+      extends RuntimeException
+      with NoStackTrace
+
+  implicit class CacheXtensionCompat[F[_], K, V](val self: Cache[F, K, V])
+      extends AnyVal {
+
+    /** Gets a value for specific key, or tries to load it.
+      *
+      * The difference between this method and [[Cache#getOrUpdate1]] is that
+      * this one allows the loading function to fail finding the value, i.e.
+      * return [[scala.None]].
+      *
+      * Also this method is meant to be used where [[cats.effect.Resource]] is
+      * not convenient to use, i.e. when integration with legacy code is
+      * required or for internal implementation. For all other cases it is
+      * recommended to use [[#getOrUpdateResourceOpt]] instead as more
+      * human-readable alternative.
+      *
+      * @param key
+      *   The key to return the value for.
+      * @param value
+      *   The function to run to load the missing value with.
+      *
+      * @tparam A
+      *   Arbitrary type of a value to return in case key was not present in a
+      *   cache.
+      *
+      * @return
+      *   The same semantics applies as in [[Cache#getOrUpdate1]], except that
+      *   the method may return [[scala.None]] in case `value` completes to
+      *   [[scala.None]].
+      */
+    def getOrUpdateOpt1Compat[A](
+        key: K
+    )(value: => F[Option[(A, V, Option[F[Unit]])]])(implicit
+        F: MonadThrow[F]
+    ): F[Option[Either[A, Either[F[V], V]]]] = {
+      self
+        .getOrUpdate1(key) {
+          value.flatMap {
+            case Some((a, value, release)) => (a, value, release).pure[F]
+            case None => NoneError.raiseError[F, (A, V, Option[F[Unit]])]
+          }
+        }
+        .map { _.some }
+        .recover { case NoneError => none }
+    }
+
+    /** Gets a value for specific key, or tries to load it.
+      *
+      * The difference between this method and [[#getOrUpdateResource]] is that
+      * this one allows the loading function to fail finding the value,
+      * i.e. return [[scala.None]].
+      *
+      * @param key
+      *   The key to return the value for.
+      * @param value
+      *   The function to run to load the missing value with.
+      *
+      * @return
+      *   The same semantics applies as in [[#getOrUpdateResource]], except that
+      *   the method may return [[scala.None]] in case `value` completes to
+      *   [[scala.None]]. The resource will be released normally even if `None`
+      *   is returned.
+      */
+    def getOrUpdateResourceOptCompat(key: K)(
+        value: => Resource[F, Option[V]]
+    )(implicit F: MonadCancel[F, Throwable]): F[Option[V]] = {
+      self
+        .getOrUpdateOpt1Compat(key) {
+          value.allocated
+            .flatMap {
+              case (Some(a), release) =>
+                (a, a, release.some).some
+                  .pure[F]
+              case (None, release) =>
+                release.as { none[(V, V, Option[F[Unit]])] }
+            }
+        }
+        .flatMap {
+          case Some(Right(Right(a))) => a.some.pure[F]
+          case Some(Right(Left(a)))  => a.map { _.some }
+          case Some(Left(a))         => a.some.pure[F]
+          case None                  => none[V].pure[F]
+        }
+    }
+  }
+
+}

--- a/src/main/scala-3/com/evolution/scache/CacheOpsCompat.scala
+++ b/src/main/scala-3/com/evolution/scache/CacheOpsCompat.scala
@@ -1,0 +1,98 @@
+package com.evolution.scache
+
+import cats.MonadThrow
+import cats.effect.MonadCancel
+import cats.effect.Resource
+import cats.syntax.all.*
+
+import scala.util.control.NoStackTrace
+
+object CacheOpsCompat {
+  private[scache] case object NoneError
+      extends RuntimeException
+      with NoStackTrace
+
+  extension [F[_], K, V](self: Cache[F, K, V]) {
+
+    /** Gets a value for specific key, or tries to load it.
+      *
+      * The difference between this method and [[Cache#getOrUpdate1]] is that
+      * this one allows the loading function to fail finding the value, i.e.
+      * return [[scala.None]].
+      *
+      * Also this method is meant to be used where [[cats.effect.Resource]] is
+      * not convenient to use, i.e. when integration with legacy code is
+      * required or for internal implementation. For all other cases it is
+      * recommended to use [[#getOrUpdateResourceOpt]] instead as more
+      * human-readable alternative.
+      *
+      * @param key
+      *   The key to return the value for.
+      * @param value
+      *   The function to run to load the missing value with.
+      *
+      * @tparam A
+      *   Arbitrary type of a value to return in case key was not present in a
+      *   cache.
+      *
+      * @return
+      *   The same semantics applies as in [[Cache#getOrUpdate1]], except that
+      *   the method may return [[scala.None]] in case `value` completes to
+      *   [[scala.None]].
+      */
+    def getOrUpdateOpt1Compat[A](
+        key: K
+    )(value: => F[Option[(A, V, Option[F[Unit]])]])(implicit
+        F: MonadThrow[F]
+    ): F[Option[Either[A, Either[F[V], V]]]] = {
+      self
+        .getOrUpdate1(key) {
+          value.flatMap {
+            case Some((a, value, release)) => (a, value, release).pure[F]
+            case None => NoneError.raiseError[F, (A, V, Option[F[Unit]])]
+          }
+        }
+        .map { _.some }
+        .recover { case NoneError => none }
+    }
+
+    /** Gets a value for specific key, or tries to load it.
+      *
+      * The difference between this method and [[#getOrUpdateResource]] is that
+      * this one allows the loading function to fail finding the value,
+      * i.e. return [[scala.None]].
+      *
+      * @param key
+      *   The key to return the value for.
+      * @param value
+      *   The function to run to load the missing value with.
+      *
+      * @return
+      *   The same semantics applies as in [[#getOrUpdateResource]], except that
+      *   the method may return [[scala.None]] in case `value` completes to
+      *   [[scala.None]]. The resource will be released normally even if `None`
+      *   is returned.
+      */
+    def getOrUpdateResourceOptCompat(key: K)(
+        value: => Resource[F, Option[V]]
+    )(implicit F: MonadCancel[F, Throwable]): F[Option[V]] = {
+      self
+        .getOrUpdateOpt1Compat(key) {
+          value.allocated
+            .flatMap {
+              case (Some(a), release) =>
+                (a, a, release.some).some
+                  .pure[F]
+              case (None, release) =>
+                release.as { none[(V, V, Option[F[Unit]])] }
+            }
+        }
+        .flatMap {
+          case Some(Right(Right(a))) => a.some.pure[F]
+          case Some(Right(Left(a)))  => a.map { _.some }
+          case Some(Left(a))         => a.some.pure[F]
+          case None                  => none[V].pure[F]
+        }
+    }
+  }
+}

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -835,7 +835,7 @@ object Cache {
       */
     def getOrUpdate2[A](
       key: K)(
-      value: => F[(A, V, Option[Cache[F, K, V]#Release])])(implicit
+      value: => F[(A, V, Option[F[Unit]])])(implicit
       F: Monad[F]
     ): F[Either[A, V]] = {
       self
@@ -875,14 +875,14 @@ object Cache {
       *   [[scala.None]].
       */
     def getOrUpdateOpt1[A](key: K)(
-      value: => F[Option[(A, V, Option[Cache[F, K, V]#Release])]])(implicit
+      value: => F[Option[(A, V, Option[F[Unit]])]])(implicit
       F: MonadThrow[F]
     ): F[Option[Either[A, Either[F[V], V]]]] = {
       self
         .getOrUpdate1(key) {
           value.flatMap {
             case Some((a, value, release)) => (a, value, release).pure[F]
-            case None                      => NoneError.raiseError[F, (A, V, Option[Cache[F, K, V]#Release])]
+            case None                      => NoneError.raiseError[F, (A, V, Option[F[Unit]])]
           }
         }
         .map { _.some }

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -376,8 +376,8 @@ object Cache {
   sealed trait Directive[+F[_], +V]
   object Directive {
     final case class Put[F[_], V](value: V, release: Option[F[Unit]]) extends Directive[F, V]
-    final case object Remove extends Directive[Nothing, Nothing]
-    final case object Ignore extends Directive[Nothing, Nothing]
+    case object Remove extends Directive[Nothing, Nothing]
+    case object Ignore extends Directive[Nothing, Nothing]
   }
 
   /** Creates an always-empty implementation of cache.

--- a/src/main/scala/com/evolution/scache/CacheMetered.scala
+++ b/src/main/scala/com/evolution/scache/CacheMetered.scala
@@ -69,7 +69,7 @@ object CacheMetered {
                 value      <- value.attempt
                 duration   <- start
                 loadSucceed = value match {
-                  case Right(_) | Left(Cache.NoneError) => true
+                  case Right(_) | Left(CacheOpsCompat.NoneError) => true
                   case Left(_)                          => false
                 }
                 _     <- metrics.load(duration, loadSucceed)

--- a/src/main/scala/com/evolution/scache/CacheMetrics.scala
+++ b/src/main/scala/com/evolution/scache/CacheMetrics.scala
@@ -72,9 +72,9 @@ object CacheMetrics {
     }
   }
   object Directive {
-    final case object Put extends Directive
-    final case object Ignore extends Directive
-    final case object Remove extends Directive
+    case object Put extends Directive
+    case object Ignore extends Directive
+    case object Remove extends Directive
   }
 
   type Name = String

--- a/src/main/scala/com/evolution/scache/LoadingCache.scala
+++ b/src/main/scala/com/evolution/scache/LoadingCache.scala
@@ -848,7 +848,7 @@ private[scache] object LoadingCache {
   object EntryState {
     final case class Loading[F[_], A](deferred: Deferred[F, Either[Throwable, Entry[F, A]]]) extends EntryState[F, A]
     final case class Value[F[_], A](entry: Entry[F, A]) extends EntryState[F, A]
-    final case object Removed extends EntryState[Nothing, Nothing]
+    case object Removed extends EntryState[Nothing, Nothing]
   }
 
   type DeferredThrow[F[_], A] = Deferred[F, Either[Throwable, A]]

--- a/src/main/scala/com/evolution/scache/LoadingCache.scala
+++ b/src/main/scala/com/evolution/scache/LoadingCache.scala
@@ -881,9 +881,8 @@ private[scache] object LoadingCache {
   implicit class EntryStateOps[F[_], A](val self: EntryState[F, A]) extends AnyVal {
 
     def getOption(implicit F: Applicative[F]): F[Option[Entry[F, A]]] ={
-      implicit val f: Functor[F] = F
       self match {
-        case EntryState.Loading(deferred) => deferred.getOption(f)
+        case EntryState.Loading(deferred) => deferred.getOption
         case EntryState.Value(entry) => entry.some.pure[F]
         case EntryState.Removed => none[Entry[F, A]].pure[F]
       }}

--- a/src/main/scala/com/evolution/scache/LoadingCache.scala
+++ b/src/main/scala/com/evolution/scache/LoadingCache.scala
@@ -880,12 +880,13 @@ private[scache] object LoadingCache {
 
   implicit class EntryStateOps[F[_], A](val self: EntryState[F, A]) extends AnyVal {
 
-    def getOption(implicit F: Applicative[F]): F[Option[Entry[F, A]]] =
+    def getOption(implicit F: Applicative[F]): F[Option[Entry[F, A]]] ={
+      implicit val f: Functor[F] = F
       self match {
-        case EntryState.Loading(deferred) => deferred.getOption
+        case EntryState.Loading(deferred) => deferred.getOption(f)
         case EntryState.Value(entry) => entry.some.pure[F]
         case EntryState.Removed => none[Entry[F, A]].pure[F]
-      }
+      }}
 
     def optEither(implicit F: MonadThrow[F]): Option[Either[F[A], A]] =
       self match {

--- a/src/main/scala/com/evolution/scache/LoadingCache.scala
+++ b/src/main/scala/com/evolution/scache/LoadingCache.scala
@@ -882,7 +882,7 @@ private[scache] object LoadingCache {
 
     def getOption(implicit F: Applicative[F]): F[Option[Entry[F, A]]] ={
       self match {
-        case EntryState.Loading(deferred) => deferred.getOption
+        case EntryState.Loading(deferred: Deferred[F, Either[Throwable, Entry[F, A]]]) => deferred.getOption
         case EntryState.Value(entry) => entry.some.pure[F]
         case EntryState.Removed => none[Entry[F, A]].pure[F]
       }}
@@ -894,7 +894,7 @@ private[scache] object LoadingCache {
             .value
             .asRight[F[A]]
             .some
-        case EntryState.Loading(deferred) =>
+        case EntryState.Loading(deferred: Deferred[F, Either[Throwable, Entry[F, A]]]) =>
           deferred
             .getOrError
             .map(_.value)
@@ -929,7 +929,7 @@ private[scache] object LoadingCache {
               .value
               .pure[F]
               .some
-          case EntryState.Loading(deferred) =>
+          case EntryState.Loading(deferred: Deferred[F, Either[Throwable, Entry[F, A]]]) =>
             deferred
               .getOrError
               .map { _.value }

--- a/src/main/scala/com/evolution/scache/SerialMap.scala
+++ b/src/main/scala/com/evolution/scache/SerialMap.scala
@@ -241,7 +241,10 @@ object SerialMap { self =>
 
   class Apply[F[_]](val F: Concurrent[F]) extends AnyVal {
 
-    def of[K, V](implicit runtime: Runtime[F]): F[SerialMap[F, K, V]] = self.of[F, K, V](F, runtime)
+    def of[K, V](implicit runtime: Runtime[F]): F[SerialMap[F, K, V]] = {
+      implicit val concurrent: Concurrent[F] = F
+      self.of[F, K, V](None)
+    }
   }
 
 

--- a/src/test/scala/com/evolution/scache/CacheSpec.scala
+++ b/src/test/scala/com/evolution/scache/CacheSpec.scala
@@ -1607,7 +1607,7 @@ object CacheSpec {
 
     def getOrUpdate1Ensure(
       key: K)(
-      value: => F[(V, Option[Cache[F, K, V]#Release])])(implicit
+      value: => F[(V, Option[F[Unit]])])(implicit
       F: Concurrent[F]
     ): F[Fiber[F, Throwable, Either[Throwable, V]]] = {
       for {
@@ -1632,7 +1632,7 @@ object CacheSpec {
 
     def getOrUpdateOpt1Ensure(
       key: K)(
-      value: => F[Option[(V, Option[Cache[F, K, V]#Release])]])(implicit
+      value: => F[Option[(V, Option[F[Unit]])]])(implicit
       F: Concurrent[F]
     ): F[Fiber[F, Throwable, Option[V]]] = {
       for {


### PR DESCRIPTION
`++3.3.0; compile`
```scala
[error] -- [E007] Type Mismatch Error: scache/src/main/scala/com/evolution/scache/LoadingCache.scala:886:64 
[error] 886 |        case EntryState.Loading(deferred) => deferred.getOption(f)
[error]     |                                                                ^
[error]     |Found:    (f : cats.Functor[F])
[error]     |Required: cats.Functor[F$1]
[error]     |
[error]     |where:    F   is a type in class EntryStateOps with bounds <: [_] =>> Any
[error]     |          F$1 is a type in method getOption with bounds <: F
```
@prolativ you're compiler expert I know, could you explain why is compiler unhappy with that piece of code? I was trying to cross-compile that lib and frankly I have no idea what to do. 